### PR TITLE
Make sure the YM2612 timers are enabled on initialization

### DIFF
--- a/Z80 Sound Driver.asm
+++ b/Z80 Sound Driver.asm
@@ -288,6 +288,11 @@ zInitAudioDriver:
 		djnz	$							; Loop in this instruction, decrementing b each iteration, until b = 0
 		dec	c								; c--
 		jr	z, .loop						; Loop if c = 0
+		
+		ld	a, 0Fh							; Make sure the YM2612 timers are enabled
+		ld	c, a
+		ld	a, 27h
+		rst	zWriteFMI
 
 		call	zStopAllSound					; Stop all music
 


### PR DESCRIPTION
Not sure about hardware, but on Genesis Plus GX, with both cores, the YM timers are disabled. Since the sound driver goes right into checking the timer before actually setting it up, it gets stuck in a loop. This fixes this by enabling the timers before entering the main loop.